### PR TITLE
Use sessionStorage to persist book selection across navigation

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -11,10 +11,7 @@ const links = [
 ];
 
 const readingList = await getCollection("nowReading");
-const randomBookEntry = readingList.length > 0 
-    ? readingList[Math.floor(Math.random() * readingList.length)] 
-    : null;
-const randomBook = randomBookEntry?.data;
+const books = readingList.map(entry => entry.data);
 
 const pathname = Astro.url.pathname.replace(import.meta.env.BASE_URL, "");
 const subpath = pathname.match(/[^\/]+/g);
@@ -74,39 +71,73 @@ function isActive(href: string) {
         <!-- Theme Toggle and Book -->
         <div class="flex items-center gap-4 md:flex-col md:gap-6">
         <ThemeToggle />
-        
-        {randomBook && (
-            <div class="group relative flex items-center justify-center">
-                <a 
-                    href={randomBook.url} 
-                    target="_blank" 
-                    rel="noopener noreferrer"
-                    class="transition-transform duration-200 hover:scale-105 flex items-center justify-center"
-                >
-                    <div class="w-6 h-9 md:w-8 md:h-12 bg-primary/5 rounded-sm overflow-hidden border border-primary/10 shadow-sm group-hover:border-secondary/50 transition-colors">
-                        {randomBook.cover ? (
-                            <img 
-                                src={randomBook.cover} 
-                                alt={randomBook.title} 
-                                class="w-full h-full object-cover grayscale-[0.2] group-hover:grayscale-0 transition-all"
-                            />
-                        ) : (
-                            <div class="w-full h-full flex items-center justify-center text-[8px] text-center p-1 opacity-50">
-                                {randomBook.title}
-                            </div>
-                        )}
-                    </div>
-                </a>
-                
-                <!-- Tooltip (Desktop only) -->
-                <div class="hidden md:block absolute top-1/2 left-full ml-4 -translate-y-1/2 px-3 py-2 bg-primary text-background text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-xl border border-white/10">
-                    <div class="font-bold">{randomBook.title}</div>
-                    <div class="opacity-70">by {randomBook.author}</div>
-                    <!-- Arrow -->
-                    <div class="absolute top-1/2 -left-1 -translate-y-1/2 w-2 h-2 bg-primary rotate-45 border-l border-t border-white/10"></div>
-                </div>
+
+        {books.length > 0 && (
+            <div id="now-reading-container" class="group relative flex items-center justify-center" data-books={JSON.stringify(books)}>
+                <!-- Book will be rendered by client-side script -->
             </div>
-            )}
+        )}
         </div>
     </div>
 </div>
+
+<script>
+    function renderNowReading() {
+        const container = document.getElementById('now-reading-container');
+        if (!container) return;
+
+        const books = JSON.parse(container.dataset.books || '[]');
+        if (books.length === 0) return;
+
+        // Get or set the session book index
+        const SESSION_KEY = 'now-reading-index';
+        let bookIndex = sessionStorage.getItem(SESSION_KEY);
+
+        if (bookIndex === null || parseInt(bookIndex) >= books.length) {
+            // Pick a random book and save to session
+            bookIndex = Math.floor(Math.random() * books.length).toString();
+            sessionStorage.setItem(SESSION_KEY, bookIndex);
+        }
+
+        const book = books[parseInt(bookIndex)];
+        if (!book) return;
+
+        // Render the book
+        container.innerHTML = `
+            <a
+                href="${book.url}"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="transition-transform duration-200 hover:scale-105 flex items-center justify-center"
+            >
+                <div class="w-6 h-9 md:w-8 md:h-12 bg-primary/5 rounded-sm overflow-hidden border border-primary/10 shadow-sm group-hover:border-secondary/50 transition-colors">
+                    ${book.cover ? `
+                        <img
+                            src="${book.cover}"
+                            alt="${book.title}"
+                            class="w-full h-full object-cover grayscale-[0.2] group-hover:grayscale-0 transition-all"
+                        />
+                    ` : `
+                        <div class="w-full h-full flex items-center justify-center text-[8px] text-center p-1 opacity-50">
+                            ${book.title}
+                        </div>
+                    `}
+                </div>
+            </a>
+
+            <!-- Tooltip (Desktop only) -->
+            <div class="hidden md:block absolute top-1/2 left-full ml-4 -translate-y-1/2 px-3 py-2 bg-primary text-background text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-xl border border-white/10">
+                <div class="font-bold">${book.title}</div>
+                <div class="opacity-70">by ${book.author}</div>
+                <!-- Arrow -->
+                <div class="absolute top-1/2 -left-1 -translate-y-1/2 w-2 h-2 bg-primary rotate-45 border-l border-t border-white/10"></div>
+            </div>
+        `;
+    }
+
+    // Initial render
+    renderNowReading();
+
+    // Re-render on Astro view transitions
+    document.addEventListener('astro:page-load', renderNowReading);
+</script>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -89,20 +89,15 @@ function isActive(href: string) {
 <script>
     function renderNowReading() {
         const container = document.getElementById('now-reading-container');
-        if (!container) return;
+        if (!container || container.children.length > 0 || !container.dataset.books) return;
 
-        // Skip if already rendered (transition:persist keeps the DOM)
-        if (container.children.length > 0) return;
-
-        const books = JSON.parse(container.dataset.books || '[]');
+        const books = JSON.parse(container.dataset.books);
         if (books.length === 0) return;
 
-        // Get or set the session book index
         const SESSION_KEY = 'now-reading-index';
         let bookIndex = sessionStorage.getItem(SESSION_KEY);
 
         if (bookIndex === null || parseInt(bookIndex) >= books.length) {
-            // Pick a random book and save to session
             bookIndex = Math.floor(Math.random() * books.length).toString();
             sessionStorage.setItem(SESSION_KEY, bookIndex);
         }
@@ -110,7 +105,6 @@ function isActive(href: string) {
         const book = books[parseInt(bookIndex)];
         if (!book) return;
 
-        // Create elements safely (no XSS risk)
         const link = document.createElement('a');
         link.href = book.url;
         link.target = '_blank';
@@ -127,38 +121,35 @@ function isActive(href: string) {
             img.className = 'w-full h-full object-cover grayscale-[0.2] group-hover:grayscale-0 transition-all';
             bookDiv.appendChild(img);
         } else {
-            const titleDiv = document.createElement('div');
-            titleDiv.className = 'w-full h-full flex items-center justify-center text-[8px] text-center p-1 opacity-50';
-            titleDiv.textContent = book.title; // Safe: textContent auto-escapes
-            bookDiv.appendChild(titleDiv);
+            const fallback = document.createElement('div');
+            fallback.className = 'w-full h-full flex items-center justify-center text-[8px] text-center p-1 opacity-50';
+            fallback.textContent = book.title;
+            bookDiv.appendChild(fallback);
         }
 
         link.appendChild(bookDiv);
 
-        // Create tooltip
         const tooltip = document.createElement('div');
         tooltip.className = 'hidden md:block absolute top-1/2 left-full ml-4 -translate-y-1/2 px-3 py-2 bg-primary text-background text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-xl border border-white/10';
 
-        const titleDiv = document.createElement('div');
-        titleDiv.className = 'font-bold';
-        titleDiv.textContent = book.title; // Safe: textContent auto-escapes
+        const title = document.createElement('div');
+        title.className = 'font-bold';
+        title.textContent = book.title;
 
-        const authorDiv = document.createElement('div');
-        authorDiv.className = 'opacity-70';
-        authorDiv.textContent = `by ${book.author}`; // Safe: textContent auto-escapes
+        const author = document.createElement('div');
+        author.className = 'opacity-70';
+        author.textContent = `by ${book.author}`;
 
         const arrow = document.createElement('div');
         arrow.className = 'absolute top-1/2 -left-1 -translate-y-1/2 w-2 h-2 bg-primary rotate-45 border-l border-t border-white/10';
 
-        tooltip.appendChild(titleDiv);
-        tooltip.appendChild(authorDiv);
+        tooltip.appendChild(title);
+        tooltip.appendChild(author);
         tooltip.appendChild(arrow);
 
-        // Add everything to container
         container.appendChild(link);
         container.appendChild(tooltip);
     }
 
-    // Initial render - runs once per session thanks to transition:persist
     renderNowReading();
 </script>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -73,7 +73,12 @@ function isActive(href: string) {
         <ThemeToggle />
 
         {books.length > 0 && (
-            <div id="now-reading-container" class="group relative flex items-center justify-center" data-books={JSON.stringify(books)}>
+            <div
+                id="now-reading-container"
+                class="group relative flex items-center justify-center"
+                data-books={JSON.stringify(books)}
+                transition:persist="now-reading"
+            >
                 <!-- Book will be rendered by client-side script -->
             </div>
         )}
@@ -85,6 +90,9 @@ function isActive(href: string) {
     function renderNowReading() {
         const container = document.getElementById('now-reading-container');
         if (!container) return;
+
+        // Skip if already rendered (transition:persist keeps the DOM)
+        if (container.children.length > 0) return;
 
         const books = JSON.parse(container.dataset.books || '[]');
         if (books.length === 0) return;
@@ -102,42 +110,55 @@ function isActive(href: string) {
         const book = books[parseInt(bookIndex)];
         if (!book) return;
 
-        // Render the book
-        container.innerHTML = `
-            <a
-                href="${book.url}"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="transition-transform duration-200 hover:scale-105 flex items-center justify-center"
-            >
-                <div class="w-6 h-9 md:w-8 md:h-12 bg-primary/5 rounded-sm overflow-hidden border border-primary/10 shadow-sm group-hover:border-secondary/50 transition-colors">
-                    ${book.cover ? `
-                        <img
-                            src="${book.cover}"
-                            alt="${book.title}"
-                            class="w-full h-full object-cover grayscale-[0.2] group-hover:grayscale-0 transition-all"
-                        />
-                    ` : `
-                        <div class="w-full h-full flex items-center justify-center text-[8px] text-center p-1 opacity-50">
-                            ${book.title}
-                        </div>
-                    `}
-                </div>
-            </a>
+        // Create elements safely (no XSS risk)
+        const link = document.createElement('a');
+        link.href = book.url;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.className = 'transition-transform duration-200 hover:scale-105 flex items-center justify-center';
 
-            <!-- Tooltip (Desktop only) -->
-            <div class="hidden md:block absolute top-1/2 left-full ml-4 -translate-y-1/2 px-3 py-2 bg-primary text-background text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-xl border border-white/10">
-                <div class="font-bold">${book.title}</div>
-                <div class="opacity-70">by ${book.author}</div>
-                <!-- Arrow -->
-                <div class="absolute top-1/2 -left-1 -translate-y-1/2 w-2 h-2 bg-primary rotate-45 border-l border-t border-white/10"></div>
-            </div>
-        `;
+        const bookDiv = document.createElement('div');
+        bookDiv.className = 'w-6 h-9 md:w-8 md:h-12 bg-primary/5 rounded-sm overflow-hidden border border-primary/10 shadow-sm group-hover:border-secondary/50 transition-colors';
+
+        if (book.cover) {
+            const img = document.createElement('img');
+            img.src = book.cover;
+            img.alt = book.title;
+            img.className = 'w-full h-full object-cover grayscale-[0.2] group-hover:grayscale-0 transition-all';
+            bookDiv.appendChild(img);
+        } else {
+            const titleDiv = document.createElement('div');
+            titleDiv.className = 'w-full h-full flex items-center justify-center text-[8px] text-center p-1 opacity-50';
+            titleDiv.textContent = book.title; // Safe: textContent auto-escapes
+            bookDiv.appendChild(titleDiv);
+        }
+
+        link.appendChild(bookDiv);
+
+        // Create tooltip
+        const tooltip = document.createElement('div');
+        tooltip.className = 'hidden md:block absolute top-1/2 left-full ml-4 -translate-y-1/2 px-3 py-2 bg-primary text-background text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-xl border border-white/10';
+
+        const titleDiv = document.createElement('div');
+        titleDiv.className = 'font-bold';
+        titleDiv.textContent = book.title; // Safe: textContent auto-escapes
+
+        const authorDiv = document.createElement('div');
+        authorDiv.className = 'opacity-70';
+        authorDiv.textContent = `by ${book.author}`; // Safe: textContent auto-escapes
+
+        const arrow = document.createElement('div');
+        arrow.className = 'absolute top-1/2 -left-1 -translate-y-1/2 w-2 h-2 bg-primary rotate-45 border-l border-t border-white/10';
+
+        tooltip.appendChild(titleDiv);
+        tooltip.appendChild(authorDiv);
+        tooltip.appendChild(arrow);
+
+        // Add everything to container
+        container.appendChild(link);
+        container.appendChild(tooltip);
     }
 
-    // Initial render
+    // Initial render - runs once per session thanks to transition:persist
     renderNowReading();
-
-    // Re-render on Astro view transitions
-    document.addEventListener('astro:page-load', renderNowReading);
 </script>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -75,11 +75,41 @@ function isActive(href: string) {
         {books.length > 0 && (
             <div
                 id="now-reading-container"
-                class="group relative flex items-center justify-center"
-                data-books={JSON.stringify(books)}
+                class="group relative"
                 transition:persist="now-reading"
             >
-                <!-- Book will be rendered by client-side script -->
+                {books.map((book, i) => (
+                    <div
+                        class="book-option hidden flex items-center justify-center"
+                        data-index={i}
+                    >
+                        <a
+                            href={book.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="transition-transform duration-200 hover:scale-105 flex items-center justify-center"
+                        >
+                            <div class="w-6 h-9 md:w-8 md:h-12 bg-primary/5 rounded-sm overflow-hidden border border-primary/10 shadow-sm group-hover:border-secondary/50 transition-colors">
+                                {book.cover ? (
+                                    <img
+                                        src={book.cover}
+                                        alt={book.title}
+                                        class="w-full h-full object-cover grayscale-[0.2] group-hover:grayscale-0 transition-all"
+                                    />
+                                ) : (
+                                    <div class="w-full h-full flex items-center justify-center text-[8px] text-center p-1 opacity-50">
+                                        {book.title}
+                                    </div>
+                                )}
+                            </div>
+                        </a>
+                        <div class="hidden md:block absolute top-1/2 left-full ml-4 -translate-y-1/2 px-3 py-2 bg-primary text-background text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-xl border border-white/10">
+                            <div class="font-bold">{book.title}</div>
+                            <div class="opacity-70">by {book.author}</div>
+                            <div class="absolute top-1/2 -left-1 -translate-y-1/2 w-2 h-2 bg-primary rotate-45 border-l border-t border-white/10"></div>
+                        </div>
+                    </div>
+                ))}
             </div>
         )}
         </div>
@@ -87,69 +117,20 @@ function isActive(href: string) {
 </div>
 
 <script>
-    function renderNowReading() {
-        const container = document.getElementById('now-reading-container');
-        if (!container || container.children.length > 0 || !container.dataset.books) return;
+    const container = document.getElementById('now-reading-container');
+    if (container) {
+        const bookOptions = container.querySelectorAll('.book-option');
 
-        const books = JSON.parse(container.dataset.books);
-        if (books.length === 0) return;
+        if (bookOptions.length > 0) {
+            const SESSION_KEY = 'now-reading-index';
+            let bookIndex = sessionStorage.getItem(SESSION_KEY);
 
-        const SESSION_KEY = 'now-reading-index';
-        let bookIndex = sessionStorage.getItem(SESSION_KEY);
+            if (bookIndex === null || parseInt(bookIndex) >= bookOptions.length) {
+                bookIndex = Math.floor(Math.random() * bookOptions.length).toString();
+                sessionStorage.setItem(SESSION_KEY, bookIndex);
+            }
 
-        if (bookIndex === null || parseInt(bookIndex) >= books.length) {
-            bookIndex = Math.floor(Math.random() * books.length).toString();
-            sessionStorage.setItem(SESSION_KEY, bookIndex);
+            bookOptions[parseInt(bookIndex)]?.classList.remove('hidden');
         }
-
-        const book = books[parseInt(bookIndex)];
-        if (!book) return;
-
-        const link = document.createElement('a');
-        link.href = book.url;
-        link.target = '_blank';
-        link.rel = 'noopener noreferrer';
-        link.className = 'transition-transform duration-200 hover:scale-105 flex items-center justify-center';
-
-        const bookDiv = document.createElement('div');
-        bookDiv.className = 'w-6 h-9 md:w-8 md:h-12 bg-primary/5 rounded-sm overflow-hidden border border-primary/10 shadow-sm group-hover:border-secondary/50 transition-colors';
-
-        if (book.cover) {
-            const img = document.createElement('img');
-            img.src = book.cover;
-            img.alt = book.title;
-            img.className = 'w-full h-full object-cover grayscale-[0.2] group-hover:grayscale-0 transition-all';
-            bookDiv.appendChild(img);
-        } else {
-            const fallback = document.createElement('div');
-            fallback.className = 'w-full h-full flex items-center justify-center text-[8px] text-center p-1 opacity-50';
-            fallback.textContent = book.title;
-            bookDiv.appendChild(fallback);
-        }
-
-        link.appendChild(bookDiv);
-
-        const tooltip = document.createElement('div');
-        tooltip.className = 'hidden md:block absolute top-1/2 left-full ml-4 -translate-y-1/2 px-3 py-2 bg-primary text-background text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-xl border border-white/10';
-
-        const title = document.createElement('div');
-        title.className = 'font-bold';
-        title.textContent = book.title;
-
-        const author = document.createElement('div');
-        author.className = 'opacity-70';
-        author.textContent = `by ${book.author}`;
-
-        const arrow = document.createElement('div');
-        arrow.className = 'absolute top-1/2 -left-1 -translate-y-1/2 w-2 h-2 bg-primary rotate-45 border-l border-t border-white/10';
-
-        tooltip.appendChild(title);
-        tooltip.appendChild(author);
-        tooltip.appendChild(arrow);
-
-        container.appendChild(link);
-        container.appendChild(tooltip);
     }
-
-    renderNowReading();
 </script>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -11,7 +11,9 @@ const links = [
 ];
 
 const readingList = await getCollection("nowReading");
-const books = readingList.map(entry => entry.data);
+const books = readingList
+    .map(entry => entry.data)
+    .filter(book => book.cover);
 
 const pathname = Astro.url.pathname.replace(import.meta.env.BASE_URL, "");
 const subpath = pathname.match(/[^\/]+/g);
@@ -90,17 +92,11 @@ function isActive(href: string) {
                             class="transition-transform duration-200 hover:scale-105 flex items-center justify-center"
                         >
                             <div class="w-6 h-9 md:w-8 md:h-12 bg-primary/5 rounded-sm overflow-hidden border border-primary/10 shadow-sm group-hover:border-secondary/50 transition-colors">
-                                {book.cover ? (
-                                    <img
-                                        src={book.cover}
-                                        alt={book.title}
-                                        class="w-full h-full object-cover grayscale-[0.2] group-hover:grayscale-0 transition-all"
-                                    />
-                                ) : (
-                                    <div class="w-full h-full flex items-center justify-center text-[8px] text-center p-1 opacity-50">
-                                        {book.title}
-                                    </div>
-                                )}
+                                <img
+                                    src={book.cover}
+                                    alt={book.title}
+                                    class="w-full h-full object-cover grayscale-[0.2] group-hover:grayscale-0 transition-all"
+                                />
                             </div>
                         </a>
                         <div class="hidden md:block absolute top-1/2 left-full ml-4 -translate-y-1/2 px-3 py-2 bg-primary text-background text-xs rounded-md opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50 shadow-xl border border-white/10">

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -22,7 +22,7 @@ const nowReading = defineCollection({
     schema: z.object({
         title: z.string(),
         author: z.string(),
-        cover: z.string().url().optional(),
+        cover: z.string().url().nullish(),
         url: z.string().url(),
     }),
 });


### PR DESCRIPTION
The "Now Reading" feature now shows the same book consistently during a
single browser session. Previously, a new random book was selected on every
page navigation. Now, the book selection is persisted in sessionStorage, so:

- Same book is shown throughout a single browser session
- Different book may appear on next visit (new session)
- Works seamlessly with Astro's view transitions

Implementation uses client-side JavaScript to handle book selection and
rendering, with the book list passed from the server via data attributes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Persist the displayed “Now Reading” book across a session using sessionStorage-driven client-side selection, rendering all candidates and allowing null covers in content schema.
> 
> - **Navigation/UI (`src/components/Navigation.astro`)**:
>   - Switch from server-side random pick to client-side selection using `sessionStorage` to persist a chosen book index across navigation.
>   - Render all `nowReading` entries with covers as hidden `.book-option` elements; reveal one based on persisted/random index.
>   - Add `transition:persist="now-reading"` for smoother view transitions and show a tooltip with title/author.
> - **Content Schema (`src/content.config.ts`)**:
>   - Change `cover` type to `z.string().url().nullish()` in `nowReading` collection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 271771265dce571e7d927f92f392d0ac4f21f9d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->